### PR TITLE
chore: clean up links and remove repo tools

### DIFF
--- a/.cloud-repo-tools.json
+++ b/.cloud-repo-tools.json
@@ -1,8 +1,0 @@
-{
-  "requiresKeyFile": true,
-  "requiresProjectId": true,
-  "product": "datalabeling",
-  "client_reference_url": "https://cloud.google.com/datalabeling/docs",
-  "release_quality": "alpha",
-  "samples": []
-}

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "datalabeling",
   "name_pretty": "Google Cloud Data Labeling",
-  "product_documentation": "https://cloud.google.com/datalabeling",
+  "product_documentation": "https://cloud.google.com/data-labeling/docs/",
   "client_documentation": "https://cloud.google.com/nodejs/docs/reference/datalabeling/latest/",
   "issue_tracker": "",
   "release_level": "alpha",

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Apache Version 2.0
 See [LICENSE](https://github.com/googleapis/nodejs-datalabeling/blob/master/LICENSE)
 
 [client-docs]: https://cloud.google.com/nodejs/docs/reference/datalabeling/latest/
-[product-docs]: https://cloud.google.com/datalabeling
+[product-docs]: https://cloud.google.com/data-labeling/docs/
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
 [projects]: https://console.cloud.google.com/project
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
   "main": "src/index.js",
   "files": [
     "protos",
-    "src",
-    "AUTHORS",
-    "COPYING"
+    "src"
   ],
   "keywords": [
     "google apis client",
@@ -31,7 +29,6 @@
   "scripts": {
     "cover": "nyc --reporter=lcov mocha test/*.js && nyc report",
     "docs": "jsdoc -c .jsdoc.js",
-    "generate-scaffolding": "repo-tools generate all && repo-tools generate lib_samples_readme -l samples/ --config ../.cloud-repo-tools.json",
     "lint": "eslint '**/*.js'",
     "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
     "system-test": "mocha system-test/*.js smoke-test/*.js --timeout 600000",
@@ -47,7 +44,6 @@
     "protobufjs": "^6.8.0"
   },
   "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "^3.0.0",
     "codecov": "^3.0.2",
     "eslint": "^5.0.1",
     "eslint-config-prettier": "^4.0.0",
@@ -60,8 +56,6 @@
     "nyc": "^14.0.0",
     "power-assert": "^1.6.0",
     "prettier": "^1.13.6",
-    "sinon": "^7.0.0",
-    "uuid": "^3.3.0",
     "linkinator": "^1.1.2"
   }
 }


### PR DESCRIPTION
This does a few misc tasks:
- removes @google-cloud/nodejs-repo-tools, sinon, and uuid modules (which weren't being used)
- fixes 404s for product docs
- removes cloud-repo-tools.json which isn't needed