### PR TITLE
fix: do not modify options object, use defaultScopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "api-documenter": "api-documenter yaml --input-folder=temp"
   },
   "dependencies": {
-    "google-gax": "^2.1.0",
+    "google-gax": "^2.9.2",
     "protobufjs": "^6.8.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@
 import * as v1beta1 from './v1beta1';
 
 const DataLabelingServiceClient = v1beta1.DataLabelingServiceClient;
+type DataLabelingServiceClient = v1beta1.DataLabelingServiceClient;
 
 export {v1beta1, DataLabelingServiceClient};
 export default {v1beta1, DataLabelingServiceClient};

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,15 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/nodejs-datalabeling.git",
-        "sha": "5280f9030714763165cdc64fcf2f9dc08a4e61e0"
-      }
-    },
-    {
-      "git": {
-        "name": "googleapis",
-        "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "062f46f246c78fde2160524db593fa0fa7bdbe64",
-        "internalRef": "337404700"
+        "remote": "git@github.com:googleapis/nodejs-datalabeling.git",
+        "sha": "317c722bc888c11f57819cd8e02babd988dad2de"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "ba9918cd22874245b55734f57470c719b577e591"
+        "sha": "1f1148d3c7a7a52f0c98077f976bd9b3c948ee2b"
       }
     }
   ],
@@ -87,6 +79,7 @@
     "README.md",
     "api-extractor.json",
     "linkinator.config.json",
+    "package-lock.json.2707288343",
     "protos/google/cloud/datalabeling/v1beta1/annotation.proto",
     "protos/google/cloud/datalabeling/v1beta1/annotation_spec_set.proto",
     "protos/google/cloud/datalabeling/v1beta1/data_labeling_service.proto",
@@ -102,6 +95,7 @@
     "protos/protos.json",
     "renovate.json",
     "samples/README.md",
+    "samples/package-lock.json.1329949583",
     "src/index.ts",
     "src/v1beta1/data_labeling_service_client.ts",
     "src/v1beta1/data_labeling_service_client_config.json",

--- a/system-test/fixtures/sample/src/index.ts
+++ b/system-test/fixtures/sample/src/index.ts
@@ -18,8 +18,17 @@
 
 import {DataLabelingServiceClient} from '@google-cloud/datalabeling';
 
+// check that the client class type name can be used
+function doStuffWithDataLabelingServiceClient(
+  client: DataLabelingServiceClient
+) {
+  client.close();
+}
+
 function main() {
-  new DataLabelingServiceClient();
+  // check that the client instance can be created
+  const dataLabelingServiceClient = new DataLabelingServiceClient();
+  doStuffWithDataLabelingServiceClient(dataLabelingServiceClient);
 }
 
 main();

--- a/system-test/install.ts
+++ b/system-test/install.ts
@@ -20,32 +20,32 @@ import {packNTest} from 'pack-n-play';
 import {readFileSync} from 'fs';
 import {describe, it} from 'mocha';
 
-describe('typescript consumer tests', () => {
-  it('should have correct type signature for typescript users', async function () {
+describe('📦 pack-n-play test', () => {
+  it('TypeScript code', async function () {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(), // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'TypeScript user can use the type definitions',
         ts: readFileSync(
           './system-test/fixtures/sample/src/index.ts'
         ).toString(),
       },
     };
-    await packNTest(options); // will throw upon error.
+    await packNTest(options);
   });
 
-  it('should have correct type signature for javascript users', async function () {
+  it('JavaScript code', async function () {
     this.timeout(300000);
     const options = {
-      packageDir: process.cwd(), // path to your module.
+      packageDir: process.cwd(),
       sample: {
-        description: 'typescript based user can use the type definitions',
+        description: 'JavaScript user can use the library',
         ts: readFileSync(
           './system-test/fixtures/sample/src/index.js'
         ).toString(),
       },
     };
-    await packNTest(options); // will throw upon error.
+    await packNTest(options);
   });
 });


### PR DESCRIPTION
Regenerated the library using
[gapic-generator-typescript](https://github.com/googleapis/gapic-generator-typescript)
v1.2.1.