### PR TITLE
chore: add api_shortname and library_type to repo metadata

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -13,5 +13,5 @@
   "api_id": "datalabeling.googleapis.com",
   "repo": "googleapis/nodejs-datalabeling",
   "api_shortname": "datalabeling",
-  "library_type": ""
+  "library_type": "GAPIC_AUTO"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "default_version": "v1beta1",
-  "release_level": "beta",
+  "release_level": "preview",
   "requires_billing": true,
   "client_documentation": "https://cloud.google.com/nodejs/docs/reference/datalabeling/latest",
   "codeowner_team": "@googleapis/ml-apis",
@@ -11,5 +11,7 @@
   "distribution_name": "@google-cloud/datalabeling",
   "name_pretty": "Google Cloud Data Labeling",
   "api_id": "datalabeling.googleapis.com",
-  "repo": "googleapis/nodejs-datalabeling"
+  "repo": "googleapis/nodejs-datalabeling",
+  "api_shortname": "datalabeling",
+  "library_type": ""
 }

--- a/README.md
+++ b/README.md
@@ -115,13 +115,12 @@ This library follows [Semantic Versioning](http://semver.org/).
 
 
 
-This library is considered to be in **beta**. This means it is expected to be
-mostly stable while we work toward a general availability release; however,
-complete stability is not guaranteed. We will address issues and requests
-against beta libraries with a high priority.
 
 
 
+This library is considered to be in **preview**. This means it is still a
+work-in-progress and under active development. Any release is subject to
+backwards-incompatible changes at any time.
 
 
 More Information: [Google Cloud Platform Launch Stages][launch_stages]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # [Google Cloud Data Labeling: Node.js Client](https://github.com/googleapis/nodejs-datalabeling)
 
-[![release level](https://img.shields.io/badge/release%20level-beta-yellow.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
+
 [![npm version](https://img.shields.io/npm/v/@google-cloud/datalabeling.svg)](https://www.npmjs.org/package/@google-cloud/datalabeling)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-datalabeling/main.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-datalabeling)
 
@@ -113,11 +113,6 @@ _Legacy Node.js versions are supported as a best effort:_
 This library follows [Semantic Versioning](http://semver.org/).
 
 
-
-This library is considered to be in **beta**. This means it is expected to be
-mostly stable while we work toward a general availability release; however,
-complete stability is not guaranteed. We will address issues and requests
-against beta libraries with a high priority.
 
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # [Google Cloud Data Labeling: Node.js Client](https://github.com/googleapis/nodejs-datalabeling)
 
-
+[![release level](https://img.shields.io/badge/release%20level-preview-yellow.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
 [![npm version](https://img.shields.io/npm/v/@google-cloud/datalabeling.svg)](https://www.npmjs.org/package/@google-cloud/datalabeling)
 
 


### PR DESCRIPTION
Update .repo-metadata.json as required by go/library-data-integrity 